### PR TITLE
facilities: crash early if facility errors at start

### DIFF
--- a/workers/base0.js
+++ b/workers/base0.js
@@ -118,7 +118,14 @@ class Base0 {
     const aseries = []
 
     aseries.push(next => {
-      this.facs('addFac', this.conf.init.facilities, next)
+      this.facs('addFac', this.conf.init.facilities, (err) => {
+        // crash early to avoid silent fails in facilities
+        if (err) {
+          console.trace()
+          throw err
+        }
+        next()
+      })
     })
 
     aseries.push(next => {


### PR DESCRIPTION
to avoid silent fails when booting a service, throw at startup in
case one of the required facs is failing.