### PR TITLE
add config helper

### DIFF
--- a/setup-config.sh
+++ b/setup-config.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+for file in $(find config -type f -name "*.example"); do
+  new_name=$(echo "$file" | sed -E -e 's/.example//')
+  echo "$file -> $new_name"
+  cp "$file" "$new_name"
+done


### PR DESCRIPTION
with many new services, copying over the `.example` configs
becomes a frequent task.

this small bash helper helps to do all the copy work for devs, and
helps us to slim down the typical `README.md` for a grenache
service.